### PR TITLE
Added stat restoration as per Issue #10

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/model/skill/SkillSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/skill/SkillSet.kt
@@ -183,7 +183,7 @@ class SkillSet(val maxSkills: Int) {
         /**
          * The maximum level a skill can reach.
          */
-        private const val MAX_LVL = 99
+        const val MAX_LVL = 99
 
         /**
          * The default amount of trainable skills by players.


### PR DESCRIPTION
## What has been done?
Added a stat restore function to Player class which initialises on login and checks temporarily boosted stats against actual stats (determined by XP), decaying the difference by 1 level every minute checked.
  -
  -
  -