### PR TITLE
Update Netty

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/protocol/GameHandler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/protocol/GameHandler.kt
@@ -22,7 +22,7 @@ import mu.KLogging
 class GameHandler(private val world: World) : ChannelInboundHandlerAdapter() {
 
     override fun channelInactive(ctx: ChannelHandlerContext) {
-        val session = ctx.channel().attr(SYSTEM_KEY).andRemove
+        val session = ctx.channel().attr(SYSTEM_KEY).getAndSet(null)
         session?.terminate()
         ctx.channel().close()
     }

--- a/gradle/properties.gradle
+++ b/gradle/properties.gradle
@@ -3,7 +3,7 @@ ext {
     junitVersion = '4.12'
     kotlinVersion = '1.8.0'
     kcoroutineVersion = '1.1.0'
-    nettyVersion = '4.0.34.Final'
+    nettyVersion = '4.1.89.Final'
     gsonVersion = '2.8.5'
     yamlVersion = '2.5.0'
     jacksonVersion = '2.5.0'


### PR DESCRIPTION
## What has been done?
Updates Netty to the latest version. This removes the `WARNING: An illegal reflective access operation has occurred` upon startup.