### PR TITLE
fix: check inventory before feathering

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/fletching/feathering/FeatherAction.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/fletching/feathering/FeatherAction.kt
@@ -2,10 +2,12 @@ package gg.rsmod.plugins.content.skills.fletching.feathering
 
 import gg.rsmod.game.fs.DefinitionSet
 import gg.rsmod.game.fs.def.ItemDef
+import gg.rsmod.game.model.container.ItemContainer
 import gg.rsmod.game.model.queue.QueueTask
 import gg.rsmod.plugins.api.Skills
 import gg.rsmod.plugins.api.cfg.Items
 import gg.rsmod.plugins.api.ext.doubleItemMessageBox
+import gg.rsmod.plugins.api.ext.message
 import gg.rsmod.plugins.api.ext.player
 import kotlin.math.min
 
@@ -57,10 +59,34 @@ class FeatherAction(private val definitions: DefinitionSet) {
         if (!inventory.contains(feathered.raw) || inventory.getItemCount(feather) < feathered.amount) {
             return false
         }
+        if (!hasRoomForProduct(inventory, feathered, feather)) {
+            task.player.message("You don't have enough inventory space to do that.")
+            return false
+        }
         if (player.getSkills().getCurrentLevel(Skills.FLETCHING) < feathered.levelRequirement) {
             task.doubleItemMessageBox("You need a ${Skills.getSkillName(player.world, Skills.FLETCHING)} level of ${feathered.levelRequirement} to fletch ${itemNames[feathered.product]}.", item1 = feathered.raw, amount1 = 100, item2 = Items.FEATHER)
             return false
         }
         return true
+    }
+
+    private fun hasRoomForProduct(inventory: ItemContainer, feathered: FeatheringData, feather: Int): Boolean {
+        if (inventory.contains(feathered.product)) {
+            return true
+        }
+
+        if (inventory.hasSpace) {
+            return true
+        }
+
+        if (inventory.getItemCount(feathered.raw) <= feathered.amount) {
+            return true
+        }
+
+        if (inventory.getItemCount(feather) <= feathered.amount * feathered.feathersRequired) {
+            return true
+        }
+
+        return false
     }
 }


### PR DESCRIPTION
## What has been done?
Feathering from an inventory that has no space for the product removes the product from the game. This ensures feathering can only be done when there's space for the product.