### PR TITLE
fix: Correctly update xp counter

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
@@ -559,7 +559,7 @@ open class Player(world: World) : Pawn(world) {
         /*
          * Updates the XP counter orb
          */
-        varps.setState(1801, varps[1801].state + (xp * 10).toInt())
+        varps.setState(1801, varps[1801].state + ((oldXp - newXp) * 10).toInt())
 
         /*
          * Only increment the 'current' level if it's set at its capped level.


### PR DESCRIPTION
## What has been done?
Takes the xp multiplier into account when updating the xp counter