### PR TITLE
fix: renew mining animation in time

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/mining/Mining.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/mining/Mining.kt
@@ -10,8 +10,11 @@ import gg.rsmod.plugins.api.EquipmentType
 import gg.rsmod.plugins.api.Skills
 import gg.rsmod.plugins.api.cfg.Items
 import gg.rsmod.plugins.api.ext.*
+import kotlin.math.min
 
 object Mining {
+    private const val MINING_ANIMATION_TIME = 16
+
     suspend fun mineRock(it: QueueTask, obj: GameObject, rock: RockType) {
         val p = it.player
 
@@ -28,49 +31,63 @@ object Mining {
 
         p.filterableMessage("You swing your pick at the rock.")
 
+        var ticks = 0
+
         while (true) {
             if (!canMine(it, p, obj, rock)) {
                 p.animate(-1)
                 break
             }
-            p.animate(pick.animation)
-            it.wait(pick.ticksBetweenRolls)
-            val level = p.getSkills().getCurrentLevel(Skills.MINING)
-            if (interpolate(rock.lowChance, rock.highChance, level) > RANDOM.nextInt(255)) {
-                p.filterableMessage("You manage to get some $oreName")
 
-                var chanceOfGem = p.world.random(256)
-                if (p.hasEquipped(EquipmentType.AMULET, Items.AMULET_OF_GLORY_1, Items.AMULET_OF_GLORY_2, Items.AMULET_OF_GLORY_3, Items.AMULET_OF_GLORY_4, Items.AMULET_OF_GLORY_T, Items.AMULET_OF_GLORY_T1, Items.AMULET_OF_GLORY_T2, Items.AMULET_OF_GLORY_T3, Items.AMULET_OF_GLORY_T4, Items.AMULET_OF_GLORY_T_10719, Items.AMULET_OF_GLORY_8283)) {
-                    chanceOfGem = p.world.random(86)
+            if (ticks % MINING_ANIMATION_TIME == 0) {
+                p.animate(pick.animation)
+            }
+            if (ticks % pick.ticksBetweenRolls == 0) {
+                val level = p.getSkills().getCurrentLevel(Skills.MINING)
+                if (interpolate(rock.lowChance, rock.highChance, level) > RANDOM.nextInt(255)) {
+                    handleSuccess(p, oreName, rock, obj)
+                    break
                 }
+            }
 
-                if(chanceOfGem == 1) {
-                    p.inventory.add(Items.UNCUT_DIAMOND + (p.world.random(0..3) * 2))
-                }
+            val time = min(MINING_ANIMATION_TIME - ticks % MINING_ANIMATION_TIME, pick.ticksBetweenRolls - ticks % pick.ticksBetweenRolls)
+            it.wait(time)
+            ticks += time
+        }
+    }
 
-                if (p.hasEquipped(EquipmentType.CHEST, Items.VARROCK_ARMOUR_1, Items.VARROCK_ARMOUR_2, Items.VARROCK_ARMOUR_3, Items.VARROCK_ARMOUR_4)) {
-                    if ((rock.varrockArmourAffected - (p.getEquipment(EquipmentType.CHEST)?.id ?: -1)) >= 0) {
-                        p.inventory.add(rock.reward)
-                    }
-                }
+    private fun handleSuccess(p: Player, oreName: String, rock: RockType, obj: GameObject) {
+        p.filterableMessage("You manage to mine some $oreName")
 
+        var chanceOfGem = p.world.random(256)
+        if (p.hasEquipped(EquipmentType.AMULET, Items.AMULET_OF_GLORY_1, Items.AMULET_OF_GLORY_2, Items.AMULET_OF_GLORY_3, Items.AMULET_OF_GLORY_4, Items.AMULET_OF_GLORY_T, Items.AMULET_OF_GLORY_T1, Items.AMULET_OF_GLORY_T2, Items.AMULET_OF_GLORY_T3, Items.AMULET_OF_GLORY_T4, Items.AMULET_OF_GLORY_T_10719, Items.AMULET_OF_GLORY_8283)) {
+            chanceOfGem = p.world.random(86)
+        }
+
+        if(chanceOfGem == 1) {
+            p.inventory.add(Items.UNCUT_DIAMOND + (p.world.random(0..3) * 2))
+        }
+
+        if (p.hasEquipped(EquipmentType.CHEST, Items.VARROCK_ARMOUR_1, Items.VARROCK_ARMOUR_2, Items.VARROCK_ARMOUR_3, Items.VARROCK_ARMOUR_4)) {
+            if ((rock.varrockArmourAffected - (p.getEquipment(EquipmentType.CHEST)?.id ?: -1)) >= 0) {
                 p.inventory.add(rock.reward)
-                p.addXp(Skills.MINING, rock.experience)
-                p.animate(-1)
-                val depletedRockId = p.world.definitions.get(ObjectDef::class.java, obj.id).depleted
-                if (depletedRockId != -1) {
-                    val world = p.world
-                    world.queue {
-                        val depletedOre = DynamicObject(obj, depletedRockId)
-                        world.remove(obj)
-                        world.spawn(depletedOre)
-                        // TODO: add support mining guild runite ore respawn timer
-                        wait(rock.respawnDelay)
-                        world.remove(depletedOre)
-                        world.spawn(DynamicObject(obj))
-                    }
-                }
-                break
+            }
+        }
+
+        p.inventory.add(rock.reward)
+        p.addXp(Skills.MINING, rock.experience)
+        p.animate(-1)
+        val depletedRockId = p.world.definitions.get(ObjectDef::class.java, obj.id).depleted
+        if (depletedRockId != -1) {
+            val world = p.world
+            world.queue {
+                val depletedOre = DynamicObject(obj, depletedRockId)
+                world.remove(obj)
+                world.spawn(depletedOre)
+                // TODO: add support mining guild runite ore respawn timer
+                wait(rock.respawnDelay)
+                world.remove(depletedOre)
+                world.spawn(DynamicObject(obj))
             }
         }
     }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/smithing/SmeltingAction.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/smithing/SmeltingAction.kt
@@ -2,6 +2,7 @@ package gg.rsmod.plugins.content.skills.smithing
 
 import gg.rsmod.game.fs.DefinitionSet
 import gg.rsmod.game.fs.def.ItemDef
+import gg.rsmod.game.model.entity.Player
 import gg.rsmod.game.model.queue.QueueTask
 import gg.rsmod.plugins.api.Skills
 import gg.rsmod.plugins.api.cfg.Items
@@ -68,7 +69,7 @@ class SmeltingAction(private val defs: DefinitionSet) {
             val removeSecondary = inventory.remove(item = bar.secondaryOre, amount = bar.secondaryCount, assureFullRemoval = true)
 
             val removedFromInventory = removePrimary.hasSucceeded() && removeSecondary.hasSucceeded()
-            val ironBarSuccess = bar.product != Items.IRON_BAR || rollIronBar(level)
+            val ironBarSuccess = bar.product != Items.IRON_BAR || rollIronBar(level, player)
 
             if (removedFromInventory && ironBarSuccess) {
                 inventory.add(bar.product)
@@ -108,7 +109,12 @@ class SmeltingAction(private val defs: DefinitionSet) {
         return true
     }
 
-    private fun rollIronBar(level: Int) = level.coerceAtMost(45).interpolate(50, 80, 15, 45, 100)
+    private fun rollIronBar(level: Int, player: Player) =
+        level.coerceAtMost(45).interpolate(50, 80, 15, 45, 100).also {
+            if (!it) {
+                player.filterableMessage("The ore is too impure and you fail to refine it.")
+            }
+        }
 
     companion object {
 


### PR DESCRIPTION
## What has been done?
- Adds the correct player message upon failing to smelt an iron bar
- Fixes the player message upon mining an ore
- Ensures the mining animation gets updated in time. Previously, it would only get updated when a pickaxe would roll for success. This decouples pickaxe rolls from animation renewal.

There's probably a better way to "loop" an animation instead of continually renewing

Github makes a mess of the diff. Basically: the "success" logic was extracted to a separate function, and some tick logic was added to the main `mineRock` function