### PR TITLE
fix: Reset damage map when npc gets reset

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/action/NpcDeathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/NpcDeathAction.kt
@@ -1,5 +1,6 @@
 package gg.rsmod.game.action
 
+import gg.rsmod.game.action.NpcDeathAction.reset
 import gg.rsmod.game.fs.def.AnimDef
 import gg.rsmod.game.model.LockState
 import gg.rsmod.game.model.attr.KILLER_ATTR
@@ -74,5 +75,6 @@ object NpcDeathAction {
         attr.clear()
         timers.clear()
         world.setNpcDefaults(this)
+        damageMap.reset()
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/combat/DamageMap.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/combat/DamageMap.kt
@@ -45,5 +45,9 @@ class DamageMap {
      */
     fun getMostDamage(type: EntityType, timeFrameMs: Long? = null): Pawn? = map.filter { it.key.entityType == type && (timeFrameMs == null || System.currentTimeMillis() - it.value.lastHit < timeFrameMs) }.maxByOrNull { it.value.totalDamage }?.key
 
+    fun reset() {
+        map.clear()
+    }
+
     data class DamageStack(val totalDamage: Int, val lastHit: Long)
 }


### PR DESCRIPTION
## What has been done?
Reset the damage map when an npc gets reset