### PR TITLE
fix: default to no weapon upon unequipping

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
@@ -494,6 +494,8 @@ fun Player.sendWeaponComponentInformation() {
     if (weapon != null) {
         val definition = world.definitions.get(ItemDef::class.java, weapon.id)
         attr[LAST_KNOWN_WEAPON_TYPE] = max(0, definition.weaponType)
+    } else {
+        attr[LAST_KNOWN_WEAPON_TYPE] = WeaponType.NONE.id
     }
 }
 


### PR DESCRIPTION
## What has been done?
I noticed I could unequip my bow while ranging, and my character would continue attacking with ranged combat instead of using fists