### PR TITLE
update apprentice smith dialogue

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/apprentice_smith.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/apprentice_smith.plugin.kts
@@ -1,74 +1,29 @@
 package gg.rsmod.plugins.content.areas.lumbridge
 
-import gg.rsmod.plugins.content.mechanics.shops.CoinCurrency
-
-create_shop("Apprentice's Smithing Shop", currency = CoinCurrency(), purchasePolicy = PurchasePolicy.BUY_NONE, containsSamples = false) {
-    items[0] = ShopItem(Items.BRONZE_PICKAXE, 1)
-    items[1] = ShopItem(Items.BRONZE_HATCHET, 1)
-    items[2] = ShopItem(Items.BRONZE_DAGGER, 1)
-    items[3] = ShopItem(Items.BRONZE_CHAINBODY, 1)
-}
-
-on_npc_option(Npcs.APPRENTICE_SMITH, option = "talk-to") {
-    player.queue { chat(this) }
-}
-
-suspend fun chat(it: QueueTask) {
-    it.chatPlayer("Hello, how's it going?")
-    when (world.random(15)) {
-        0 -> it.chatNpc("Not too bad thanks.")
-        1 -> {
-            it.chatNpc("I'm fine, how are you?")
-            it.chatPlayer("Very well thank you.")
+on_npc_option(npc = Npcs.APPRENTICE_SMITH, option = "talk-to") {
+    player.queue {
+        this.chatPlayer("Can you teach me the basics of smithing please?")
+        if (!player.hasItem(Items.COPPER_ORE) || !player.hasItem(Items.TIN_ORE)) {
+            noItemsDialogue(this)
+        } else {
+            dialogue(this)
         }
-
-        2 -> it.chatNpc("I think we need a new king...", "The one we've got isn't very good.")
-        4 -> it.chatNpc("Do I know you? I'm in a hurry!")
-        5 -> it.chatNpc("None of your business.")
-        6 -> {
-            it.chatNpc("Not too bad, but I'm a little worried about the", "increase of goblins these days.")
-            it.chatPlayer("Don't worry, I'll kill them.")
-        }
-
-        7 -> it.chatNpc("I'm busy right now.")
-        8 -> {
-            it.chatNpc("Who are you?")
-            it.chatPlayer("I'm a bold adventurer.")
-            it.chatNpc("Ah, a very noble profession.")
-        }
-
-        9 -> it.chatNpc("No, I don't have any spare change.")
-        10 -> {
-            it.chatNpc("How can I help you?")
-            when (
-                it.options(
-                    "Do you have anything for sale?",
-                    "I'm in search of a quest.",
-                    "I'm in search of enemies to kill.",
-                )
-            ) {
-                1 -> {
-                    it.chatPlayer("Do you have anything for sale?")
-                    it.chatNpc("Here's what the smithing shop is selling.")
-                    it.player.openShop("Apprentice's Smithing Shop")
-                }
-
-                2 -> {
-                    it.chatPlayer("I'm in search of a quest.")
-                    it.chatNpc("I'm sorry I can't help you there.")
-                }
-
-                3 -> {
-                    it.chatPlayer("I'm in search of enemies to kill.")
-                    it.chatNpc("I've heard there are many fearsome creatures", "that dwell under the ground...")
-                }
-            }
-        }
-
-        11 -> it.chatNpc("I'm very well thank you.")
-        12 -> it.chatNpc("I'm a little worried. I've heard there are people going", "about killing citizens at random!")
-        13 -> it.chatNpc("That is classified information.")
-        14 -> it.chatNpc("A good axe is like a trusty friend,", "it'll never let you down when you need it most!")
-        15 -> it.chatNpc("No, I don't want to buy anything!")
     }
+}
+
+suspend fun noItemsDialogue(task: QueueTask) {
+    task.itemMessageBox("Look for this icon on your minimap to find a furnance to smelt ores into metal.", 2349)
+    task.chatNpc("You'll need to have mined some ore to smelt first. Go", "see the mining tutor to the south if you're not", "sure how to do this.")
+    task.itemMessageBox("Look for this icon on your minimap to find a furnance to smelt ores into metal.", 1265)
+}
+
+suspend fun dialogue(task: QueueTask) {
+    task.itemMessageBox("Look for this icon on your minimap to find a furnace to smelt ores into metal.", 2349)
+    task.chatNpc("I see you have some ore with you to smelt so let's get", "started.")
+    task.chatNpc("Click on the furnace to bring up a menu of metal bars", "you can try to make from your ore.")
+    task.chatNpc("When you have a full inventory, take it to the bank,", "you can find it on the roof of the castle in Lumbridge.")
+    task.itemMessageBox("To find a bank, look for this symbol on your minimap after climbing the stairs of the Lumbridge Castle to the top. There are banks all over the world with this symbol.", Items.BANKERS_NOTE)
+    task.chatNpc("If you have a hammer with you, you can smith the", "bronze bars into equipment on the anvil outside")
+    task.chatNpc("I'm afraid the weather over the years has rusted it", "down so it can only be used to work bronze.")
+    task.chatNpc("Alternatively you can run up to Varrock. Look for my", "Master, the Smithing Tutor, in the west of the city,", "he can help you smith better gear.")
 }


### PR DESCRIPTION
## What has been done?

- Update Apprentice Smith dialogue to OldSchool RuneScape's current dialogue.

The items displayed in the message boxes need to be changed to the map icons representing a bank booth and furnace. To my knowledge, I thought these were sprites from cache dumps I have seen, so I was not sure how to display or find them. So, displayed are currently placeholder images, but they are similar to the dialogue message. I've written this sub-issue down in my own little project tasks, but I can always add it as an issue on here if need be.
